### PR TITLE
feat: Apply explicit dual-path pattern in ClaimCheckSourceTransform.apply() #103

### DIFF
--- a/core/src/main/java/com/github/cokelee777/kafka/connect/smt/claimcheck/ClaimCheckSinkTransform.java
+++ b/core/src/main/java/com/github/cokelee777/kafka/connect/smt/claimcheck/ClaimCheckSinkTransform.java
@@ -35,15 +35,15 @@ public class ClaimCheckSinkTransform implements Transformation<SinkRecord> {
 
   public ClaimCheckSinkTransform() {}
 
-  public ClaimCheckSinkTransformConfig getConfig() {
+  ClaimCheckSinkTransformConfig getConfig() {
     return config;
   }
 
-  public ClaimCheckStorage getStorage() {
+  ClaimCheckStorage getStorage() {
     return storage;
   }
 
-  public RecordSerializer getRecordSerializer() {
+  RecordSerializer getRecordSerializer() {
     return recordSerializer;
   }
 
@@ -59,6 +59,8 @@ public class ClaimCheckSinkTransform implements Transformation<SinkRecord> {
     storage.configure(configs);
 
     recordSerializer = RecordSerializerFactory.create();
+
+    log.info("ClaimCheck sink transform configured: storage={}", config.getStorageType());
   }
 
   @Override
@@ -69,7 +71,9 @@ public class ClaimCheckSinkTransform implements Transformation<SinkRecord> {
 
     Header claimCheckHeader = record.headers().lastWithName(ClaimCheckSchema.NAME);
     if (claimCheckHeader == null || claimCheckHeader.value() == null) {
-      log.debug("No claim-check header or value found for record from topic: {}", record.topic());
+      if (log.isDebugEnabled()) {
+        log.debug("No claim-check header or value found for record from topic: {}", record.topic());
+      }
       return record;
     }
 
@@ -98,10 +102,12 @@ public class ClaimCheckSinkTransform implements Transformation<SinkRecord> {
     String referenceUrl = claimCheckValue.referenceUrl();
     int originalSizeBytes = claimCheckValue.originalSizeBytes();
 
-    log.debug(
-        "Recovering claim check record from: {}, original size: {} bytes",
-        referenceUrl,
-        originalSizeBytes);
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "Recovering claim check record from: {}, original size: {} bytes",
+          referenceUrl,
+          originalSizeBytes);
+    }
 
     byte[] originalRecordBytes = storage.retrieve(referenceUrl);
     validateRetrievedPayload(originalRecordBytes, referenceUrl, originalSizeBytes);


### PR DESCRIPTION
## 📄 Summary

- apply explicit dual-path pattern in ClaimCheckSourceTransform.apply()
- add debug log optimization
- remove public access for getter method and provide pacakge level access

* closed #103 

## 🔍 Type of change

* [ ] Bug
* [ ] Feature
* [x] Refactor / Internal improvement
* [ ] Documentation

## 🧪 How has this been tested?

Describe the tests that you ran to verify your changes.

* [x] Unit tests
* [x] Integration tests
* [x] Manual testing

## ✅ Checklist

* [x] My code follows the project style guidelines
* [x] I have added tests that prove my fix is effective
* [x] I have updated the documentation if needed
