### PR TITLE
docs: fix Debezium MySQL CDC Source Connector tested version from 2.1.4 to 2.6.2 #133

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ structured data using Kafka Connect's `Schema` and `Struct` API.
 
 | Connector                               | Tested Version | Status     | Notes                                                                                |
 |-----------------------------------------|----------------|------------|--------------------------------------------------------------------------------------|
-| **Debezium MySQL CDC Source Connector** | 2.1.4          | ✅ Verified | Tested with Debezium CDC envelope (before/after/source/op) and deeply nested schemas |
+| **Debezium MySQL CDC Source Connector** | 2.6.2          | ✅ Verified | Tested with Debezium CDC envelope (before/after/source/op) and deeply nested schemas |
 | **Confluent JDBC Source Connector**     | 10.7.6         | ✅ Verified | Tested with complex nested Struct schemas (non-CDC, snapshot-based records)          |
 
 *Sink Connectors (ClaimCheckSinkTransform):*


### PR DESCRIPTION
## 📄 Summary

Correct the tested version of Debezium MySQL CDC Source Connector in the **Tested and Verified** table of `README.md`. The version was incorrectly written as `2.1.4`; the correct tested version is `2.6.2`.

* closed #133

## 🔍 Type of change

* [ ] Bug
* [ ] Feature
* [ ] Refactor / Internal improvement
* [x] Documentation

## 🧪 How has this been tested?

Describe the tests that you ran to verify your changes.

* [ ] Unit tests
* [ ] Integration tests
* [x] Manual testing

## ✅ Checklist

* [x] My code follows the project style guidelines
* [ ] I have added tests that prove my fix is effective
* [x] I have updated the documentation if needed